### PR TITLE
Make sure colour level is set to 0 when a bulb is identified as off.

### DIFF
--- a/src/main/java/org/openhab/binding/espmilighthub/handler/EspMilightHubBridgeHandler.java
+++ b/src/main/java/org/openhab/binding/espmilighthub/handler/EspMilightHubBridgeHandler.java
@@ -162,7 +162,7 @@ public class EspMilightHubBridgeHandler extends BaseBridgeHandler implements Mqt
             if ("0".equals(bulbLevel) || bulbState.contains("OFF")) {
                 updateState(new ChannelUID(channelPrefix + CHANNEL_LEVEL), new PercentType(0));
                 updateState(new ChannelUID(channelPrefix + CHANNEL_LEVEL), OnOffType.valueOf("OFF"));
-                return;
+                iBulbLevel = 0;
             } else {
                 iBulbLevel = Math.round(Float.valueOf(bulbLevel));
                 // logger.trace("iBulbLevel\t={}", iBulbLevel);


### PR DESCRIPTION
When a bulb is set to off, the level is set to 0. However, not for `:colour`, because of the shortcircuiting in the bridge handler.

This pull request removes some of the shortcircuiting, and the `:colour` level is appropriately set to 0.

This allows `:colour` channel to be used as a brightness equivalent properly.