### PR TITLE
Powerfails to mindim  {“state”:“ON”,“level”:0} then {“state”:“OFF”} previously needed work around changed to {“state”:“OFF”,“level”:0}

### DIFF
--- a/src/main/java/org/openhab/binding/espmilighthub/handler/EspMilightHubBridgeHandler.java
+++ b/src/main/java/org/openhab/binding/espmilighthub/handler/EspMilightHubBridgeHandler.java
@@ -423,7 +423,7 @@ public class EspMilightHubBridgeHandler extends BaseBridgeHandler implements Mqt
 
         try {
             if (fifoOutgoingTopic.size() > 1 && fifoOutgoingTopic.getLast().equals(topic)
-                    && !fifoOutgoingPayload.getLast().equals("{\"state\":\"ON\",\"level\":0}")) {
+                    && !fifoOutgoingPayload.getLast().equals("{\"state\":\"OFF\",\"level\":0}")) {
                 lockOutGoing.lock();
                 try {
                     logger.debug("Message reduction has removed a MQTT message.");

--- a/src/main/java/org/openhab/binding/espmilighthub/handler/EspMilightHubHandler.java
+++ b/src/main/java/org/openhab/binding/espmilighthub/handler/EspMilightHubHandler.java
@@ -98,9 +98,10 @@ public class EspMilightHubHandler extends BaseThingHandler {
                         bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\"}");
                     } else {
                         if (bridgeHandler.getPowerFailsToMaxDim()) {
-                            bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"ON\",\"level\":0}");
+                            bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\",\"level\":0}");
+                        } else {
+                            bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\"}");
                         }
-                        bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\"}");
                     }
                     return;
                 } else if ("ON".equals(command.toString())) {
@@ -179,10 +180,10 @@ public class EspMilightHubHandler extends BaseThingHandler {
                 } else if ("0".equals(command.toString()) || "OFF".equals(command.toString())) {
 
                     if (bridgeHandler.getPowerFailsToMaxDim()) {
-                        bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"ON\",\"level\":0}");
+                        bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\",\"level\":0}");
+                    } else {
+                        bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\"}");
                     }
-
-                    bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\"}");
                     break;
                 }
 
@@ -207,10 +208,10 @@ public class EspMilightHubHandler extends BaseThingHandler {
                     else if (hsb.getBrightness().intValue() == 0) {
 
                         if (bridgeHandler.getPowerFailsToMaxDim()) {
-                            bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"ON\",\"level\":0}");
+                            bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\",\"level\":0}");
+                        } else {
+                            bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\"}");
                         }
-
-                        bridgeHandler.queueToSendMQTT(topic, "{\"state\":\"OFF\"}");
                         break;
                     }
                     // Handle feature for CONFIG_RGBW_WHITEMODE_SAT_THRESHOLD//////////////////////////////////////


### PR DESCRIPTION
As per our conversation I changed the previously needed {“state”:“ON”,“level”:0} then {“state”:“OFF”} work around to the now correctly working {“state”:“OFF”,“level”:0} when POWERFAILS_TO_MINDIM is true.

This avoids brief light flashes if a :level channel assigned Switch receives multiple OFF commands either directly or through a group assignment.